### PR TITLE
fixed image tag "x" and "y" attributes

### DIFF
--- a/svg2pdf.js
+++ b/svg2pdf.js
@@ -568,6 +568,8 @@ SOFTWARE.
     var canvas = document.createElement("canvas");
     var width = parseFloat(node.getAttribute("width")),
         height = parseFloat(node.getAttribute("height"));
+        x = parseFloat(node.getAttribute("x"));
+        y = parseFloat(node.getAttribute("y"));
     canvas.width = width;
     canvas.height = height;
     var context = canvas.getContext("2d");
@@ -578,8 +580,8 @@ SOFTWARE.
 
     _pdf.addImage(jpegUrl,
         "jpeg",
-        0,
-        0,
+        x,
+        y,
         width,
         height
     );


### PR DESCRIPTION
The "x" and "y" attributes of an image tag weren't taken into account so images were always rendered at 0,0
