### PR TITLE
RGBColor needs to declare "channels" variable

### DIFF
--- a/rgbcolor.js
+++ b/rgbcolor.js
@@ -214,7 +214,7 @@ function RGBColor(color_string)
     var processor = color_defs[i].process;
     var bits = re.exec(color_string);
     if (bits) {
-      channels = processor(bits);
+      var channels = processor(bits);
       this.r = channels[0];
       this.g = channels[1];
       this.b = channels[2];


### PR DESCRIPTION
The "channels" variable needs to be declared. All other undeclared variables are browser/node globals and don't seem to break.