### PR TITLE
Fixed the incorrect SvgPath AMD dependency

### DIFF
--- a/src/svg2pdf.js
+++ b/src/svg2pdf.js
@@ -1443,7 +1443,7 @@ SOFTWARE.
   };
 
   if (typeof define === "function" && define.amd) {
-    define(["./rgbcolor", "./SvgPath"], function (rgbcolor, svgpath) {
+    define(["./rgbcolor", "SvgPath"], function (rgbcolor, svgpath) {
       RGBColor = rgbcolor;
       SvgPath = svgpath;
       return svg2pdf;


### PR DESCRIPTION
This fixes the AMD definition of the SvgPath dependency "./SvgPath" which is currently relative and breaks if you try to use svg2pdfs.js with ES2015 style imports. The CommonJS definition is correct and unaltered.

Longer term might it be worth letting the build tool add the UMD wrapper?