### PR TITLE
Fix building on case-sensitive filesystems

### DIFF
--- a/src/svg2pdf.js
+++ b/src/svg2pdf.js
@@ -2316,7 +2316,7 @@ SOFTWARE.
   };
 
   if (typeof define === "function" && define.amd) {
-    define(["./rgbcolor", "SvgPath", "font-family-papandreou", "cssesc"], function (rgbcolor, svgpath, fontFamily, cssesc) {
+    define(["./rgbcolor", "svgpath", "font-family-papandreou", "cssesc"], function (rgbcolor, svgpath, fontFamily, cssesc) {
       RGBColor = rgbcolor;
       SvgPath = svgpath;
       FontFamily = fontFamily;

--- a/src/svg2pdf.js
+++ b/src/svg2pdf.js
@@ -2325,7 +2325,7 @@ SOFTWARE.
     });
   } else if (typeof module !== "undefined" && module.exports) {
     RGBColor = require("./rgbcolor.js");
-    SvgPath = require("SvgPath");
+    SvgPath = require("svgpath");
     FontFamily = require("font-family-papandreou");
     cssEsc = require("cssesc");
     module.exports = svg2pdf;


### PR DESCRIPTION
Use the right casing for the `svgpath` module,
so browserify finds it on case-sensitive file systems.

resolve #91