### PR TITLE
Fixes #91: case sensitivity problem in build

### DIFF
--- a/src/svg2pdf.js
+++ b/src/svg2pdf.js
@@ -2325,7 +2325,7 @@ SOFTWARE.
     });
   } else if (typeof module !== "undefined" && module.exports) {
     RGBColor = require("./rgbcolor.js");
-    SvgPath = require("SvgPath");
+    SvgPath = require("svgpath");
     FontFamily = require("font-family-papandreou");
     cssEsc = require("cssesc");
     module.exports = svg2pdf;


### PR DESCRIPTION
Works on Windows, but breaks on case sensitive file systems. The node module is a lower case "svgpath"!
Fixes issue #91