### PR TITLE
Utilize DOMPurify hooks to preserve <use> elements in playground mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test-typescript": "karma start ./test/deployment/typescript/karma.conf.js",
     "test:ci": "cross-env SHOW_DIFF=true npm run test",
     "createreferences": "node test/common/reference-server.js",
-    "prettier": "prettier --write {src,tests,typings}/**/*.{ts,js}",
-    "lint": "eslint {src,tests,typings}/**/*.{ts,js}"
+    "prettier": "prettier --write {playground,src,tests,typings}/**/*.{ts,js}",
+    "lint": "eslint {playground,src,tests,typings}/**/*.{ts,js}"
   },
   "repository": {
     "type": "git",

--- a/playground/index.js
+++ b/playground/index.js
@@ -1,6 +1,15 @@
 const { jsPDF } = window.jspdf
 const DOMPurify = window.DOMPurify
 
+DOMPurify.addHook('afterSanitizeAttributes', node => {
+  if (
+    (node.hasAttribute('xlink:href') && !node.getAttribute('xlink:href').match(/^#/)) ||
+    (node.hasAttribute('href') && !node.getAttribute('href').match(/^#/))
+  ) {
+    node.remove()
+  }
+})
+
 const defaultSample = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 150">
   <text x="20" y="20">Hello, world!</text>
 </svg>`
@@ -25,7 +34,7 @@ window.addEventListener('load', () => {
 editor.on(
   'change',
   debounce(() => {
-    const svgText = DOMPurify.sanitize(doc.getValue())
+    const svgText = DOMPurify.sanitize(doc.getValue(), { ADD_TAGS: ['use'] })
     updateUrl(svgText)
     updateIssueLinks()
     updateSvg(svgText)


### PR DESCRIPTION
Closes #155. 

`<use>` tags were filtered out after sanitization, but with DOMPurify hooks this problem can be solved (regular expression still filter out links to external resources in the interest of security).

Can be checked in playground with following SVG code:
```svg
<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
  <style type="text/css">
    use { fill: orange; }
  </style>
  <g class="special" style="fill: blue">
    <g id="face">
      <circle cx="50" cy="50" r="40" stroke="#000000" />
      <circle cx="30" cy="40" r="5" fill="#000000" />
      <circle cx="70" cy="40" r="5" fill="#000000" />
      <path
        fill="none"
        stroke="#000000"
        stroke-width="3"
        stroke-linecap="round"
        d="M30,60 C30,80 70,80 70,60" />
    </g>
  </g>
  <use xlink:href="#face" x="100" />
</svg>
```

**Before PR**
![image](https://user-images.githubusercontent.com/5957177/95088307-6f772700-072b-11eb-971a-12bb328c912e.png)

**After PR**
![image](https://user-images.githubusercontent.com/5957177/95087653-a4cf4500-072a-11eb-92df-e1dc66d06f1f.png)