### PR TITLE
Fix building: peer dependency, es2016

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "cssesc": "^3.0.0",
     "font-family-papandreou": "^0.2.0-patch1",
-    "svgpath": "^2.3.0",
-    "specificity": "^0.4.1"
+    "specificity": "^0.4.1",
+    "svgpath": "^2.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^5.0.2",
@@ -62,11 +62,11 @@
     "@typescript-eslint/parser": "^3.6.1",
     "chai": "^4.2.0",
     "chalk": "^4.1.0",
+    "cross-env": "^7.0.2",
+    "cssesc": "^3.0.0",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "cross-env": "^7.0.2",
-    "cssesc": "^3.0.0",
     "exorcist": "^1.0.1",
     "font-family-papandreou": "^0.2.0-patch1",
     "jspdf": "^2.4.0",
@@ -87,6 +87,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^6.1.0",
     "ts-loader": "^8.0.0",
+    "tslib": "^2.4.0",
     "typescript": "^3.9.6",
     "webpack": "^4.43.0",
     "yarpm": "^0.2.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "lib": ["dom", "es2015"],
+    "lib": ["dom", "es2016"],
     "sourceMap": true
   },
   "include": [


### PR DESCRIPTION
I just tried building this myself, and ran into two issues:

1. Modern NPM no longer installs peer dependencies automatically. So I added the required peer dependency `tslib` as a devDependency.
2. `Array.prototype.includes` (as used in `textchunk.ts` on line 94) requires es2016, so I increased the version in `.tsconfig`.

With these changes, I can build. 🙂 