### PR TITLE
Include `./src` in packaged tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "browser": "dist/svg2pdf.es.min.js",
   "files": [
     "dist/**",
+    "src/**",
     "types.d.ts",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
Closes #219.

By including the `./src` folder in the packaged tarball (https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files), the already existing source map files installed with `npm install svg2pdf.js` today should then become valid.