### PR TITLE
Fix <use> with no contents

### DIFF
--- a/src/nodes/geometrynode.ts
+++ b/src/nodes/geometrynode.ts
@@ -80,7 +80,7 @@ export abstract class GeometryNode extends GraphicsNode {
 
   protected getBoundingBoxCore(context: Context): Rect {
     const path = this.getCachedPath(context)
-    if (!path) {
+    if (!path || !path.segments.length) {
       return [0, 0, 0, 0]
     }
     let minX = Number.POSITIVE_INFINITY

--- a/test/common/tests.js
+++ b/test/common/tests.js
@@ -55,6 +55,7 @@ window.tests = [
   'style-sheets',
   'svg-viewbox',
   'svg-use',
+  'svg-use-empty',
   'symbols',
   'text-fill-stroke',
   'text-placement',

--- a/test/specs/svg-use-empty/reference.pdf
+++ b/test/specs/svg-use-empty/reference.pdf
@@ -1,0 +1,284 @@
+%PDF-1.3
+%ºß¬à
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/MediaBox [0 0 0. 0.]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 193
+>>
+stream
+0.200025 w
+0 G
+q
+1. 0. 0. -1. 0. 0. cm
+q
+1. 0. 0. 1. 0. 0. cm
+1. w
+0. g
+q
+1. 0. 0. 1. 0. 0. cm
+0. 0. 0. 0. re
+W
+n
+q
+q
+/GS1 gs
+q
+0. 0. 0. 0. 0. 0. cm
+q
+1. 0. 0. 1. 0. 0. cm
+/Xo1 Do
+Q
+Q
+Q
+Q
+Q
+Q
+Q
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+6 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+7 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+9 0 obj
+<<
+/Type /Font
+/BaseFont /Courier
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+10 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+11 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-Oblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/BaseFont /Courier-BoldOblique
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+13 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Roman
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+14 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+16 0 obj
+<<
+/Type /Font
+/BaseFont /Times-BoldItalic
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+17 0 obj
+<<
+/Type /Font
+/BaseFont /ZapfDingbats
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+18 0 obj
+<<
+/Type /Font
+/BaseFont /Symbol
+/Subtype /Type1
+/FirstChar 32
+/LastChar 255
+>>
+endobj
+19 0 obj
+<<
+/ca 1.
+/CA 0.
+>>
+endobj
+20 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0. 0. 0. 0.]
+/Matrix [1. 0. 0. 1. 0. 0.]
+/Length 3
+>>
+stream
+q
+Q
+endstream
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+/F2 6 0 R
+/F3 7 0 R
+/F4 8 0 R
+/F5 9 0 R
+/F6 10 0 R
+/F7 11 0 R
+/F8 12 0 R
+/F9 13 0 R
+/F10 14 0 R
+/F11 15 0 R
+/F12 16 0 R
+/F13 17 0 R
+/F14 18 0 R
+>>
+/ExtGState <<
+/GS1 19 0 R
+>>
+/XObject <<
+/Xo1 20 0 R
+>>
+>>
+endobj
+21 0 obj
+<<
+/Producer (jsPDF 1.0.0)
+/CreationDate (D:19871210000000+00'00')
+>>
+endobj
+22 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000360 00000 n 
+0000002344 00000 n 
+0000000015 00000 n 
+0000000116 00000 n 
+0000000417 00000 n 
+0000000542 00000 n 
+0000000672 00000 n 
+0000000805 00000 n 
+0000000942 00000 n 
+0000001065 00000 n 
+0000001194 00000 n 
+0000001326 00000 n 
+0000001462 00000 n 
+0000001590 00000 n 
+0000001717 00000 n 
+0000001846 00000 n 
+0000001979 00000 n 
+0000002081 00000 n 
+0000002177 00000 n 
+0000002213 00000 n 
+0000002633 00000 n 
+0000002719 00000 n 
+trailer
+<<
+/Size 23
+/Root 22 0 R
+/Info 21 0 R
+/ID [ <00000000000000000000000000000000> <00000000000000000000000000000000> ]
+>>
+startxref
+2823
+%%EOF

--- a/test/specs/svg-use-empty/spec.svg
+++ b/test/specs/svg-use-empty/spec.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 150">
+  <defs>
+    <path id="MJX-34-TEX-N-2061" d=""/>
+  </defs>
+  <use href="#MJX-34-TEX-N-2061" />
+</svg>


### PR DESCRIPTION
Fixes #278 by correctly checking for empty paths in `GeometryNode.prototype.getBoundingBoxCore`. Indeed, the line mentioned in https://github.com/yWorks/svg2pdf.js/issues/278#issuecomment-1842474779 had a bug that wasn't correctly checking for empty paths.

I've confirmed that this fixes #278 in my setting. I didn't add tests because I don't know how they're organized...