### PR TITLE
Provide `href` attribute support in `a` elements

### DIFF
--- a/src/nodes/group.ts
+++ b/src/nodes/group.ts
@@ -1,6 +1,6 @@
 import { Context } from '../context/context'
 import { ContainerNode } from './containernode'
-import { svgNodeAndChildrenVisible } from '../utils/node'
+import { svgNodeAndChildrenVisible, getAttribute } from '../utils/node'
 import { Matrix } from 'jspdf'
 
 export class Group extends ContainerNode {
@@ -10,5 +10,20 @@ export class Group extends ContainerNode {
 
   protected computeNodeTransformCore(context: Context): Matrix {
     return context.pdf.unitMatrix
+  }
+}
+
+export class GroupA extends Group {
+  protected async renderCore(context: Context): Promise<void> {
+    await super.renderCore(context)
+
+    const href = getAttribute(this.element, context.styleSheets, 'href')
+    if (href) {
+      const box = this.getBoundingBox(context)
+      const scale = context.pdf.internal.scaleFactor
+      const ph = context.pdf.internal.pageSize.getHeight()
+
+      context.pdf.link(scale*box[0], ph - scale*box[1], scale*box[2], scale*box[3], { url: href });
+    }
   }
 }

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -24,6 +24,7 @@ interface TrimInfo {
 }
 
 export class TextNode extends GraphicsNode {
+  private boundingBox: number[] = []
   private processTSpans(
     textNode: SvgNode,
     node: Element,
@@ -159,6 +160,9 @@ export class TextNode extends GraphicsNode {
           renderingMode: textRenderingMode === 'fill' ? void 0 : textRenderingMode,
           charSpace: charSpace === 0 ? void 0 : charSpace
         })
+        this.boundingBox = [textX + dx - xOffset, textY + dy - pdfFontSize, context.textMeasure.measureTextWidth(transformedText, context.attributeState), pdfFontSize];
+        if (alignmentBaseline === 'baseline')
+          this.boundingBox[1] += pdfFontSize*0.2;
       }
     } else {
       // otherwise loop over tspans and position each relative to the previous one
@@ -228,7 +232,7 @@ export class TextNode extends GraphicsNode {
   }
 
   protected getBoundingBoxCore(context: Context): Rect {
-    return defaultBoundingBox(this.element, context)
+    return this.boundingBox.length > 0 ? this.boundingBox : defaultBoundingBox(this.element, context)
   }
 
   protected computeNodeTransformCore(context: Context): Matrix {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,7 @@ import { LinearGradient } from './nodes/lineargradient'
 import { RadialGradient } from './nodes/radialgradient'
 import { Polyline } from './nodes/polyline'
 import { Svg } from './nodes/svg'
-import { Group } from './nodes/group'
+import { Group, GroupA } from './nodes/group'
 import cssesc from 'cssesc'
 import { ClipPath } from './nodes/clippath'
 import { Symbol } from './nodes/symbol'
@@ -29,6 +29,8 @@ export function parse(node: Element, idMap?: { [id: string]: SvgNode }): SvgNode
 
   switch (node.tagName.toLowerCase()) {
     case 'a':
+      svgnode = new GroupA(node, children)
+      break
     case 'g':
       svgnode = new Group(node, children)
       break

--- a/src/utils/bbox.ts
+++ b/src/utils/bbox.ts
@@ -7,9 +7,18 @@ export function getBoundingBoxByChildren(context: Context, svgnode: SvgNode): nu
   if (getAttribute(svgnode.element, context.styleSheets, 'display') === 'none') {
     return [0, 0, 0, 0]
   }
-  let boundingBox = [0, 0, 0, 0]
+  let boundingBox : number[] = [];
   svgnode.children.forEach(child => {
     const nodeBox = child.getBoundingBox(context)
+    if ((nodeBox[0] === 0) && (nodeBox[1] === 0) && (nodeBox[2] === 0) && (nodeBox[3] === 0))
+       return;
+    const transform = child.computeNodeTransform(context);
+    // TODO: check and apply rotation matrix if any
+    nodeBox[0] += transform.tx;
+    nodeBox[1] += transform.ty;
+    if (boundingBox.length === 0)
+      boundingBox = nodeBox;
+    else
     boundingBox = [
       Math.min(boundingBox[0], nodeBox[0]),
       Math.min(boundingBox[1], nodeBox[1]),
@@ -19,7 +28,7 @@ export function getBoundingBoxByChildren(context: Context, svgnode: SvgNode): nu
         Math.min(boundingBox[1], nodeBox[1])
     ]
   })
-  return boundingBox
+  return boundingBox.length === 0 ? [0, 0, 0, 0] : boundingBox;
 }
 
 export function defaultBoundingBox(element: Element, context: Context): Rect {


### PR DESCRIPTION
This PR provide possible solution for #312 

To be able use `jsPDF.link()` method, one need to have valid bounding box for all child nodes of `a` element.

Seems to be, existing implementation of `getBoundingBoxByChildren` function is not correct.
First commit excludes dummy box (all 0) from consideration. 
Also transformation attributes from child nodes are taken into account - for now only translations.

While `text` node is most probable candidate to be used inside `a` element - one have to provide reasonable bounding box implementation for it. In the PR second method is just workaround to avoid re-implementation of rendering again to just get bounding box. Provided solution works only for plain `text` without tspan elements inside.

Last commit implements `GroupA` class which extends normal `Group` rendering and creates link in the PDF document.
Here some internals of jsPDF context are used  - maybe better solution can be provided.