### PR TITLE
Add width and height options to the jsPdf constructor in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [#102](https://github.com/yWorks/svg2pdf.js/issues/102) for details.
 import { jsPDF } from 'jspdf'
 import 'svg2pdf.js'
 
-const pdf = new jsPDF(width > height ? 'l' : 'p', 'pt', [width, height])
+const doc = new jsPDF(width > height ? 'l' : 'p', 'pt', [width, height])
 
 const element = document.getElementById('svg')
 doc

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [#102](https://github.com/yWorks/svg2pdf.js/issues/102) for details.
 import { jsPDF } from 'jspdf'
 import 'svg2pdf.js'
 
-const doc = new jsPDF()
+const pdf = new jsPDF(width > height ? 'l' : 'p', 'pt', [width, height])
 
 const element = document.getElementById('svg')
 doc


### PR DESCRIPTION
Since it took me some time to figure out why my pdf wasn't sizing to the size of the svg.